### PR TITLE
Cycle 2412

### DIFF
--- a/Airspace.xml
+++ b/Airspace.xml
@@ -136,7 +136,6 @@
         <STAR Name="AKAM1A" ApproachName="RNPZ" />
         <STAR Name="AVNO1A" ApproachName="RNPZ" />
         <STAR Name="AVNO1E" ApproachName="RNP-ARV" />
-        <STAR Name="AVOC6A" ApproachName="RNPZ" />
         <STAR Name="BELE7A" ApproachName="RNPZ" />
         <STAR Name="BELE5E" ApproachName="RNP-ARY" />
         <STAR Name="BELE2J" ApproachName="RNPZ" />
@@ -157,7 +156,6 @@
         <SID Name="KADE6Q" />
         <SID Name="NZCH5B" />
         <SID Name="PEDM1Q" />
-        <STAR Name="AVOC6B" ApproachName="RNPZ" />
         <STAR Name="BELE7B" ApproachName="RNPZ" />
         <STAR Name="BELE5F" ApproachName="RNP-ARY" />
         <STAR Name="BELE2K" ApproachName="RNPZ" />
@@ -397,6 +395,7 @@
       <Runway Name="33" DataRunway="33">
         <SID Name="HOBSO2" />
         <SID Name="OBKO1Q" />
+        <SID Name="OBKO1R" />
         <SID Name="UPGA1Q" />
         <SID Name="WAIHU2" />
         <STAR Name="DUKE1B" ApproachName="RNP" />
@@ -794,7 +793,7 @@
         <STAR Name="FALS2B" ApproachName="RNP" />
         <STAR Name="GOBU1B" ApproachName="RNP" />
         <STAR Name="OLDO2B" ApproachName="RNP" />
-        <STAR Name="OROP1B" ApproachName="RNP" />
+        <STAR Name="OROP2B" ApproachName="RNP" />
         <STAR Name="PIBO1B" ApproachName="RNP" />
         <STAR Name="URBU2B" ApproachName="RNP" />
       </Runway>
@@ -816,22 +815,15 @@
     </Airport>
     <Airport Name="NZTU">
       <Runway Name="02" DataRunway="02">
-        <SID Name="BIDN2P" />
         <SID Name="ELDA1T" />
-        <STAR Name="DUBO2J" ApproachName="RNP" />
         <STAR Name="ELDA2J" ApproachName="RNP" />
-        <STAR Name="MAMU2J" ApproachName="RNP" />
-        <STAR Name="PORU2J" ApproachName="RNP" />
       </Runway>
       <Runway Name="11" DataRunway="11" />
       <Runway Name="20" DataRunway="20">
         <SID Name="MUKE2Q" />
         <STAR Name="DOPO2K" ApproachName="RNP" />
-        <STAR Name="DUBO1K" ApproachName="RNP" />
         <STAR Name="ELDA2K" ApproachName="RNP" />
         <STAR Name="ELDA1L" ApproachName="RNP" />
-        <STAR Name="MAMU1K" ApproachName="RNP" />
-        <STAR Name="PORU1K" ApproachName="RNP" />
       </Runway>
       <Runway Name="29" DataRunway="29" />
     </Airport>
@@ -929,7 +921,7 @@
         <STAR Name="TPAP5A" ApproachName="RNPY" />
         <STAR Name="TPAP3C" ApproachName="RNP-ARX" />
         <STAR Name="WARD6A" ApproachName="RNPY" />
-        <STAR Name="WARD3C" ApproachName="RNP-ARX" />
+        <STAR Name="WARD4C" ApproachName="RNP-ARX" />
       </Runway>
     </Airport>
     <Airport Name="NZWO">
@@ -2691,7 +2683,6 @@ TU NDB/
 MAMUS
 </Airway>
     <Airway Name="Q472">
-WB VOR/
 IPMIR/
 AVKEX
 </Airway>
@@ -4653,8 +4644,8 @@ RILEY
     <Point Name="LOCIY" Type="Fix">-425017.700+1711102.620</Point>
     <Point Name="LOSGA" Type="Fix">-365403.800+1744427.210</Point>
     <Point Name="LOSKO" Type="Fix">-454801.700+1701800.760</Point>
-    <Point Name="LOSTI" Type="Fix">-450430.850+1682250.870</Point>
     <Point Name="LOSTI" Type="Fix">-450431.000+1682251.000</Point>
+    <Point Name="LOSTI" Type="Fix">-450430.850+1682250.870</Point>
     <Point Name="LOTLO" Type="Fix">-435646.230-1785226.520</Point>
     <Point Name="LOTRA" Type="Fix">-201358.750-1590554.080</Point>
     <Point Name="LOVTA" Type="Fix">-415913.950+1713635.160</Point>
@@ -4878,7 +4869,7 @@ RILEY
     <Point Name="NOTSE" Type="Fix">-141640.660-1703648.460</Point>
     <Point Name="NOVTO" Type="Fix">-434301.320+1722942.000</Point>
     <Point Name="NOVTU" Type="Fix">-411311.310+1740223.630</Point>
-    <Point Name="NU" Type="Fix">-190428.981-1695454.950</Point>
+    <Point Name="NU" Type="Fix">-190428.980-1695454.950</Point>
     <Point Name="NUGLI" Type="Fix">-243251.440-1700000.000</Point>
     <Point Name="NUKBI" Type="Fix">-352131.910+1740257.470</Point>
     <Point Name="NUKTO" Type="Fix">-394112.720+1742640.840</Point>
@@ -6338,8 +6329,8 @@ RILEY
     <Point Name="KAI IWI BEACH" Type="Fix">-395310.900+1745401.170</Point>
     <Point Name="KAINGAROA" Type="Fix">-382430.600+1763356.500</Point>
     <Point Name="KAIPO SADDLE" Type="Fix">-442703.800+1675925.200</Point>
-    <Point Name="KAITUNA BRIDGE" Type="Fix">-412842.400+1734844.400</Point>
     <Point Name="KAITUNA BRIDGE" Type="Fix">-374446.800+1762115.500</Point>
+    <Point Name="KAITUNA BRIDGE" Type="Fix">-412842.400+1734844.400</Point>
     <Point Name="KARAKA" Type="Fix">-370437.500+1745541.700</Point>
     <Point Name="KARANGAHAPE" Type="Fix">-384742.700+1754801.700</Point>
     <Point Name="KAREWA ISLAND" Type="Fix">-373146.800+1760754.500</Point>
@@ -7334,6 +7325,9 @@ RILEY
       <Route Runway="15">SAKIM/OBKOP</Route>
     </SID>
     <SID Name="OBKO1Q" Airport="NZKK" Runways="33">
+      <Route Runway="33">KK738/NUKBI/VEDNA/SAKIM/OBKOP</Route>
+    </SID>
+    <SID Name="OBKO1R" Airport="NZKK" Runways="33">
       <Route Runway="33">KK726/KK877/SAKIM/OBKOP</Route>
     </SID>
     <SID Name="PAKAR2" Airport="NZKK" Runways="15">
@@ -7845,14 +7839,6 @@ RILEY
     <SID Name="MARKO3" Airport="NZTK" Runways="18,36">
       <Route Runway="18">BENVU/MARKO</Route>
       <Route Runway="36">BENVU/MARKO</Route>
-    </SID>
-    <SID Name="BIDN2P" Airport="NZTU" Runways="02">
-      <Route Runway="02">BIDNI</Route>
-      <Transition Name="DUBON">DALUM/DUBON</Transition>
-      <Transition Name="ELDAK">ELDAK</Transition>
-      <Transition Name="MAMUS">DALUM/MAMUS</Transition>
-      <Transition Name="OLGAL">ATSOK/DOPOP/OLGAL</Transition>
-      <Transition Name="OMARU">ATSOK/OMARU</Transition>
     </SID>
     <SID Name="ELDA1T" Airport="NZTU" Runways="02">
       <Route Runway="02">SUNPA/ELDAK</Route>
@@ -8400,12 +8386,6 @@ RILEY
       <Transition Name="IPRAK">IPRAK/UPVES</Transition>
       <Transition Name="KIDAL">KIDAL/CH413</Transition>
     </STAR>
-    <STAR Name="AVOC6A" Airport="NZCH" Runways="02">
-      <Route Runway="02">AVOCA/BISUP/CH414/UBDAN/ALBAD</Route>
-    </STAR>
-    <STAR Name="AVOC6B" Airport="NZCH" Runways="20">
-      <Route Runway="20">AVOCA/RIVPI/CH422/OBDOR/ODISI</Route>
-    </STAR>
     <STAR Name="BELE7A" Airport="NZCH" Runways="02">
       <Route Runway="02">BELEE/AVOCA/BISUP/CH426/UGEKI/IDUBU</Route>
       <Transition Name="KABKA">KABKA</Transition>
@@ -8867,7 +8847,7 @@ RILEY
       <Route Runway="34">NR VOR/UPSEG/EPGUM</Route>
     </STAR>
     <STAR Name="NR1E" Airport="NZNR" Runways="34">
-      <Route Runway="34">NR VOR/AKINA</Route>
+      <Route Runway="34">NR VOR/SANON</Route>
     </STAR>
     <STAR Name="NR1F" Airport="NZNR" Runways="16">
       <Route Runway="16">NR VOR/AROPA</Route>
@@ -9189,7 +9169,7 @@ RILEY
     <STAR Name="OROP2A" Airport="NZTG" Runways="07">
       <Route Runway="07">OROPI/MORTA</Route>
     </STAR>
-    <STAR Name="OROP1B" Airport="NZTG" Runways="25">
+    <STAR Name="OROP2B" Airport="NZTG" Runways="25">
       <Route Runway="25">OROPI/SALOL/TODAN</Route>
     </STAR>
     <STAR Name="PIBO1A" Airport="NZTG" Runways="07">
@@ -9207,12 +9187,6 @@ RILEY
     <STAR Name="DOPO2K" Airport="NZTU" Runways="20">
       <Route Runway="20">DOPOP/BIDNI</Route>
     </STAR>
-    <STAR Name="DUBO2J" Airport="NZTU" Runways="02">
-      <Route Runway="02">DUBON/TU426/DOPOP</Route>
-    </STAR>
-    <STAR Name="DUBO1K" Airport="NZTU" Runways="20">
-      <Route Runway="20">DUBON/MOVBO/ANGAX/IDKOV/LUVAB</Route>
-    </STAR>
     <STAR Name="ELDA2J" Airport="NZTU" Runways="02">
       <Route Runway="02">ELDAK/BIDNI/DOPOP</Route>
     </STAR>
@@ -9221,18 +9195,6 @@ RILEY
     </STAR>
     <STAR Name="ELDA1L" Airport="NZTU" Runways="20">
       <Route Runway="20">ELDAK/SUNPA</Route>
-    </STAR>
-    <STAR Name="MAMU2J" Airport="NZTU" Runways="02">
-      <Route Runway="02">MAMUS/TU411/DOPOP</Route>
-    </STAR>
-    <STAR Name="MAMU1K" Airport="NZTU" Runways="20">
-      <Route Runway="20">MAMUS/UGVAV/LUVAB</Route>
-    </STAR>
-    <STAR Name="PORU2J" Airport="NZTU" Runways="02">
-      <Route Runway="02">PORUT/TU537/TU479/DOPOP</Route>
-    </STAR>
-    <STAR Name="PORU1K" Airport="NZTU" Runways="20">
-      <Route Runway="20">PORUT/UPTAX/LUVAB</Route>
     </STAR>
     <STAR Name="AVPO1J" Airport="NZWB" Runways="24">
       <Route Runway="24">AVPOD/LUTKA</Route>
@@ -9372,7 +9334,7 @@ RILEY
     <STAR Name="WARD4B" Airport="NZWN" Runways="16">
       <Route Runway="16">WARDS/OMDOX/UPMOM/AGVEG/UDIVA/PHNIX/OLVIR/HUWIT/WITBY</Route>
     </STAR>
-    <STAR Name="WARD3C" Airport="NZWN" Runways="34">
+    <STAR Name="WARD4C" Airport="NZWN" Runways="34">
       <Route Runway="34">WARDS/OMDOX/SALTI/MEEDA</Route>
     </STAR>
     <STAR Name="WARD4D" Airport="NZWN" Runways="16">

--- a/Airspace.xml
+++ b/Airspace.xml
@@ -2683,6 +2683,7 @@ TU NDB/
 MAMUS
 </Airway>
     <Airway Name="Q472">
+WB VOR/
 IPMIR/
 AVKEX
 </Airway>

--- a/Maps/NZCH/CH_ACU.xml
+++ b/Maps/NZCH/CH_ACU.xml
@@ -171,10 +171,6 @@
     <Line>
       <!--Rwy02 AVNO1E-->
     </Line>
-    <Line>
-      <!--Rwy02 AVOC6A-->
-      AVOCA/BISUP/CH414/UBDAN
-    </Line>
     <Line Pattern="Solid">
       <!--Rwy02 BELE7A.KABKA-->
       KABKA/BELEE
@@ -189,7 +185,7 @@
     </Line>
     <Line>
       <!--Rwy02 BELE7A-->
-      BELEE/AVOCA/CH426/UGEKI/IDUBU
+      BELEE/AVOCA/BISUP/CH426/UGEKI/IDUBU
     </Line>
     <Line Pattern="Solid">
       <!--Rwy02 BELE5E.KABKA-->
@@ -202,7 +198,7 @@
     </Line>
     <Line>
       <!--Rwy02 BELE5E-->
-      CH414/LEVGO
+      BISUP/CH414/LEVGO
     </Line>
     <Line Pattern="Solid">
       <!--Rwy02 BELE2J.KABKA-->
@@ -215,6 +211,7 @@
     </Line>
     <Line>
       <!--Rwy02 BELE2J-->
+      CH414/UBDAN
     </Line>
     <Line>
       <!--Rwy02 ELDA1C-->
@@ -280,14 +277,14 @@
       <Point>UPVES</Point>
       <Point>KIDAL</Point>
       <Point>CH413</Point>
-      <Point>AVOCA</Point>
-      <Point>BISUP</Point>
-      <Point>CH414</Point>
       <Point>KABKA</Point>
       <Point>BELEE</Point>
       <Point>OSOLO</Point>
       <Point>VANDA</Point>
+      <Point>AVOCA</Point>
+      <Point>BISUP</Point>
       <Point>CH426</Point>
+      <Point>CH414</Point>
       <Point>ELDAK</Point>
       <Point>HODDE</Point>
       <Point>ANLIL</Point>
@@ -308,7 +305,6 @@
     <Label HasLeader="true">
       <Point>AKAMO</Point>
       <Point>AVNOP</Point>
-      <Point>AVOCA</Point>
       <Point>BELEE</Point>
       <Point>ELDAK</Point>
       <Point>GUKAM</Point>
@@ -539,10 +535,6 @@
     </Label>
   </Map>
   <Map Type="System2" Name="20 STARs" Priority="1" CustomColourName="ProcArr" Center="-43.474989+172.548286">
-    <Line>
-      <!--Rwy20 AVOC6B-->
-      AVOCA/RIVPI/CH422/OBDOR/ODISI
-    </Line>
     <Line Pattern="Solid">
       <!--Rwy20 BELE7B.KABKA-->
       KABKA/BELEE
@@ -557,7 +549,7 @@
     </Line>
     <Line>
       <!--Rwy20 BELE7B-->
-      BELEE/AVOCA
+      BELEE/AVOCA/RIVPI/CH422/OBDOR/ODISI
     </Line>
     <Line Pattern="Solid">
       <!--Rwy20 BELE5F.KABKA-->
@@ -673,14 +665,14 @@
       <Point>DIVSU</Point>
     </Symbol>
     <Symbol Type="HollowTriangle">
-      <Point>AVOCA</Point>
-      <Point>RIVPI</Point>
-      <Point>CH422</Point>
-      <Point>OBDOR</Point>
       <Point>KABKA</Point>
       <Point>BELEE</Point>
       <Point>OSOLO</Point>
       <Point>VANDA</Point>
+      <Point>AVOCA</Point>
+      <Point>RIVPI</Point>
+      <Point>CH422</Point>
+      <Point>OBDOR</Point>
       <Point>CH511</Point>
       <Point>CH406</Point>
       <Point>DOPKI</Point>
@@ -712,7 +704,6 @@
       <Point>CH408</Point>
     </Symbol>
     <Label HasLeader="true">
-      <Point>AVOCA</Point>
       <Point>BELEE</Point>
       <Point>IDPER</Point>
       <Point>LALAP</Point>

--- a/Maps/NZKK/KK_ACU.xml
+++ b/Maps/NZKK/KK_ACU.xml
@@ -111,11 +111,15 @@
     </Line>
     <Line Pattern="Dashed">
       <!--Rwy33 OBKO1Q-->
-      KK15T/-35.187280+173.890430/KK726/KK877/SAKIM/OBKOP
+      KK15T/-35.187280+173.890430/KK738/NUKBI/VEDNA/SAKIM/OBKOP
+    </Line>
+    <Line Pattern="Dashed">
+      <!--Rwy33 OBKO1R-->
+      -35.187280+173.890430/KK726/KK877/SAKIM
     </Line>
     <Line Pattern="Dashed">
       <!--Rwy33 UPGA1Q-->
-      -35.187280+173.890430/KK738/NUKBI/URGAR/UPGAM
+      NUKBI/URGAR/UPGAM
     </Line>
     <Line Pattern="Dashed">
       <!--Rwy33 WAIHU2-->
@@ -127,12 +131,13 @@
     <Symbol Type="HollowTriangle">
       <Point>KK15T</Point>
       <Point>KOPPA</Point>
-      <Point>KK726</Point>
-      <Point>KK877</Point>
-      <Point>SAKIM</Point>
-      <Point>OBKOP</Point>
       <Point>KK738</Point>
       <Point>NUKBI</Point>
+      <Point>VEDNA</Point>
+      <Point>SAKIM</Point>
+      <Point>OBKOP</Point>
+      <Point>KK726</Point>
+      <Point>KK877</Point>
       <Point>URGAR</Point>
       <Point>UPGAM</Point>
       <Point>KAROA</Point>

--- a/Maps/NZNR/NR_ACU.xml
+++ b/Maps/NZNR/NR_ACU.xml
@@ -254,7 +254,7 @@
     </Line>
     <Line>
       <!--Rwy34 NR1E-->
-      NR VOR/-39.585230+177.002440/-39.615400+176.921890/AKINA
+      NR VOR/-39.585230+177.002440/-39.615400+176.921890/SANON
     </Line>
     <Line Pattern="Solid">
       <!--Rwy34 PANI2B.POTEX-->
@@ -267,7 +267,7 @@
     <Symbol Type="HollowTriangle">
       <Point>VETAB</Point>
       <Point>EPGUM</Point>
-      <Point>AKINA</Point>
+      <Point>SANON</Point>
     </Symbol>
     <Symbol Type="Circle">
       <Point>NR VOR</Point>
@@ -293,7 +293,7 @@
       <Point>POTEX</Point>
       <Point>VETAB</Point>
       <Point>EPGUM</Point>
-      <Point>AKINA</Point>
+      <Point>SANON</Point>
     </Label>
   </Map>
   <Map Type="System2" Name="34 RNP" Priority="1" Center="-39.477694+176.866311" CustomColourName="ProcArr">

--- a/Maps/NZTG/TG_ACU.xml
+++ b/Maps/NZTG/TG_ACU.xml
@@ -218,7 +218,7 @@
       OLDON/LINPI/TODAN
     </Line>
     <Line>
-      <!--Rwy25 OROP1B-->
+      <!--Rwy25 OROP2B-->
       OROPI/SALOL/TODAN
     </Line>
     <Line>

--- a/Maps/NZTU/TU_ACU.xml
+++ b/Maps/NZTU/TU_ACU.xml
@@ -2,91 +2,32 @@
 <Maps>
   <Map Type="System2" Name="02 SIDs" Priority="1" CustomColourName="ProcDep" Center="-44.294633+171.231261">
     <Line Pattern="Dashed">
-      <!--Rwy02 BIDN2P-->
-      -44.294633+171.231261/TU20T/-44.278194+171.251250/BIDNI
-    </Line>
-    <Line Pattern="Dashed">
-      <!--Rwy02 BIDN2P.DUBON-->
-      BIDNI/DALUM/DUBON
-    </Line>
-    <Line Pattern="Dashed">
-      <!--Rwy02 BIDN2P.ELDAK-->
-      BIDNI/ELDAK
-    </Line>
-    <Line Pattern="Dashed">
-      <!--Rwy02 BIDN2P.MAMUS-->
-      DALUM/MAMUS
-    </Line>
-    <Line Pattern="Dashed">
-      <!--Rwy02 BIDN2P.OLGAL-->
-      BIDNI/ATSOK/DOPOP/OLGAL
-    </Line>
-    <Line Pattern="Dashed">
-      <!--Rwy02 BIDN2P.OMARU-->
-      ATSOK/OMARU
-    </Line>
-    <Line Pattern="Dashed">
       <!--Rwy02 ELDA1T-->
-      TU20T/SUNPA/ELDAK
+      -44.294633+171.231261/TU20T/SUNPA/ELDAK
     </Line>
     <Symbol Type="HollowTriangle">
       <Point>TU20T</Point>
-      <Point>BIDNI</Point>
-      <Point>DALUM</Point>
-      <Point>DUBON</Point>
-      <Point>ELDAK</Point>
-      <Point>MAMUS</Point>
-      <Point>ATSOK</Point>
-      <Point>DOPOP</Point>
-      <Point>OLGAL</Point>
-      <Point>OMARU</Point>
       <Point>SUNPA</Point>
+      <Point>ELDAK</Point>
     </Symbol>
     <Label HasLeader="true">
-      <Point>BIDNI</Point>
       <Point>ELDAK</Point>
-      <Point>DUBON</Point>
-      <Point>MAMUS</Point>
-      <Point>OLGAL</Point>
-      <Point>OMARU</Point>
     </Label>
   </Map>
   <Map Type="System2" Name="02 STARs" Priority="1" CustomColourName="ProcArr" Center="-44.303272+171.220639">
     <Line>
-      <!--Rwy02 DUBO2J-->
-      DUBON/TU426/DOPOP
-    </Line>
-    <Line>
       <!--Rwy02 ELDA2J-->
       ELDAK/BIDNI/DOPOP
-    </Line>
-    <Line>
-      <!--Rwy02 MAMU2J-->
-      MAMUS/TU411/DOPOP
-    </Line>
-    <Line>
-      <!--Rwy02 PORU2J-->
-      PORUT/TU537/TU479/DOPOP
     </Line>
     <Symbol Type="HollowTriangle">
       <Point>DOPOP</Point>
     </Symbol>
     <Symbol Type="HollowTriangle">
-      <Point>DUBON</Point>
-      <Point>TU426</Point>
       <Point>ELDAK</Point>
       <Point>BIDNI</Point>
-      <Point>MAMUS</Point>
-      <Point>TU411</Point>
-      <Point>PORUT</Point>
-      <Point>TU537</Point>
-      <Point>TU479</Point>
     </Symbol>
     <Label HasLeader="true">
-      <Point>DUBON</Point>
       <Point>ELDAK</Point>
-      <Point>MAMUS</Point>
-      <Point>PORUT</Point>
       <Point>DOPOP</Point>
     </Label>
   </Map>
@@ -168,10 +109,6 @@
       DOPOP/BIDNI
     </Line>
     <Line>
-      <!--Rwy20 DUBO1K-->
-      DUBON/MOVBO/ANGAX/IDKOV/LUVAB
-    </Line>
-    <Line>
       <!--Rwy20 ELDA2K-->
       ELDAK/BIDNI
     </Line>
@@ -179,39 +116,18 @@
       <!--Rwy20 ELDA1L-->
       ELDAK/SUNPA
     </Line>
-    <Line>
-      <!--Rwy20 MAMU1K-->
-      MAMUS/UGVAV/LUVAB
-    </Line>
-    <Line>
-      <!--Rwy20 PORU1K-->
-      PORUT/UPTAX/LUVAB
-    </Line>
     <Symbol Type="HollowTriangle">
       <Point>BIDNI</Point>
-      <Point>LUVAB</Point>
       <Point>SUNPA</Point>
     </Symbol>
     <Symbol Type="HollowTriangle">
       <Point>DOPOP</Point>
-      <Point>DUBON</Point>
-      <Point>MOVBO</Point>
-      <Point>ANGAX</Point>
-      <Point>IDKOV</Point>
       <Point>ELDAK</Point>
-      <Point>MAMUS</Point>
-      <Point>UGVAV</Point>
-      <Point>PORUT</Point>
-      <Point>UPTAX</Point>
     </Symbol>
     <Label HasLeader="true">
       <Point>DOPOP</Point>
-      <Point>DUBON</Point>
       <Point>ELDAK</Point>
-      <Point>MAMUS</Point>
-      <Point>PORUT</Point>
       <Point>BIDNI</Point>
-      <Point>LUVAB</Point>
       <Point>SUNPA</Point>
     </Label>
   </Map>

--- a/Maps/NZWN/WN_ACU.xml
+++ b/Maps/NZWN/WN_ACU.xml
@@ -641,7 +641,7 @@
       WARDS/OMDOX/SALTI/MEEDA
     </Line>
     <Line>
-      <!--Rwy34 WARD3C-->
+      <!--Rwy34 WARD4C-->
     </Line>
     <Symbol Type="HollowTriangle">
       <Point>UMAGA</Point>

--- a/RestrictedAreas.xml
+++ b/RestrictedAreas.xml
@@ -1,314 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <RestrictedAreas>
   <Areas>
-    <RestrictedArea Type="Danger" Name="D121 ONETAUNGA BAY" AltitudeFloor="0" AltitudeCeiling="1500" DAIWEnabled="true" LinePattern="Dotted">
-      <Area>
--364905.800+1744150.000/
--364906.046+1744153.514/
--364906.777+1744156.921/
--364907.970+1744200.118/
--364909.590+1744203.008/
--364911.587+1744205.502/
--364913.900+1744207.526/
--364916.459+1744209.017/
--364919.186+1744209.930/
--364922.000+1744210.238/
--364924.813+1744209.930/
--364927.540+1744209.017/
--364930.100+1744207.527/
--364932.413+1744205.503/
--364934.410+1744203.009/
--364936.029+1744200.119/
--364937.223+1744156.922/
--364937.954+1744153.514/
--364938.200+1744150.000/
--364937.954+1744146.486/
--364937.223+1744143.078/
--364936.029+1744139.881/
--364934.410+1744136.991/
--364932.413+1744134.497/
--364930.100+1744132.473/
--364927.540+1744130.983/
--364924.813+1744130.070/
--364922.000+1744129.762/
--364919.186+1744130.070/
--364916.459+1744130.983/
--364913.900+1744132.474/
--364911.587+1744134.498/
--364909.590+1744136.992/
--364907.970+1744139.882/
--364906.777+1744143.079/
--364906.046+1744146.486/
--364905.800+1744150.000</Area>
-      <Activations>
-        <Activation H24="true" Start="0000" End="0000" />
-      </Activations>
-    </RestrictedArea>
-    <RestrictedArea Type="Danger" Name="D125 TIRITIRI MATANGI" AltitudeFloor="0" AltitudeCeiling="0" DAIWEnabled="true" LinePattern="Dotted">
-      <Area>
--363131.800+1745456.900/
--363530.000+1745456.900/
--363530.000+1745240.400/
--363636.300+1745240.400/
--363617.500+1745020.000/
--363542.000+1744900.000/
--363131.800+1744900.000/
--363131.800+1745456.900</Area>
-      <Activations />
-    </RestrictedArea>
-    <RestrictedArea Type="Danger" Name="D130 WHANGAPARAOA HEAD" AltitudeFloor="0" AltitudeCeiling="1200" DAIWEnabled="true" LinePattern="Dotted">
-      <Area>
--363350.200+1745240.400/
--363636.300+1745240.400/
--363617.500+1745020.000/
--363542.000+1744900.000/
--363350.200+1744900.000/
--363350.200+1745240.400</Area>
-      <Activations>
-        <Activation H24="true" Start="0000" End="0000" />
-      </Activations>
-    </RestrictedArea>
-    <RestrictedArea Type="Danger" Name="D235 DRURY AERODROME" AltitudeFloor="0" AltitudeCeiling="2500" DAIWEnabled="true" LinePattern="Dotted">
-      <Area>
--370447.200+1745831.800/
--370448.111+1745844.860/
--370450.818+1745857.523/
--370455.237+1745909.405/
--370501.235+1745920.145/
--370508.629+1745929.417/
--370517.195+1745936.938/
--370526.673+1745942.482/
--370536.775+1745945.878/
--370547.193+1745947.024/
--370557.612+1745945.884/
--370607.715+1745942.492/
--370617.195+1745936.953/
--370625.763+1745929.433/
--370633.160+1745920.161/
--370639.160+1745909.419/
--370643.581+1745857.533/
--370646.288+1745844.865/
--370647.200+1745831.800/
--370646.288+1745818.735/
--370643.581+1745806.067/
--370639.160+1745754.181/
--370633.160+1745743.439/
--370625.763+1745734.167/
--370617.195+1745726.647/
--370607.715+1745721.108/
--370557.612+1745717.716/
--370547.193+1745716.576/
--370536.775+1745717.722/
--370526.673+1745721.118/
--370517.195+1745726.662/
--370508.629+1745734.183/
--370501.235+1745743.455/
--370455.237+1745754.195/
--370450.818+1745806.077/
--370448.111+1745818.740/
--370447.200+1745831.800</Area>
-      <Activations>
-        <Activation H24="true" Start="0000" End="0000" />
-      </Activations>
-    </RestrictedArea>
-    <RestrictedArea Type="Danger" Name="D323 TARERE FOREST" AltitudeFloor="0" AltitudeCeiling="2600" DAIWEnabled="true" LinePattern="Dotted">
-      <Area>
--393243.700+1743406.600/
--393703.700+1743132.600/
--393541.700+1742634.600/
--393458.700+1742659.600/
--393157.700+1742808.600/
--393144.700+1743003.600/
--393243.700+1743406.600</Area>
-      <Activations>
-        <Activation H24="true" Start="0000" End="0000" />
-      </Activations>
-    </RestrictedArea>
-    <RestrictedArea Type="Danger" Name="D522 MANGAHAO" AltitudeFloor="0" AltitudeCeiling="2500" DAIWEnabled="true" LinePattern="Dotted">
-      <Area>
--402644.700+1754848.800/
--402928.000+1754552.000/
--402910.200+1754341.700/
--402800.300+1754059.200/
--402640.800+1754130.500/
--402610.100+1754221.100/
--402544.400+1754717.600/
--402644.700+1754848.800</Area>
-      <Activations>
-        <Activation H24="true" Start="0000" End="0000" />
-      </Activations>
-    </RestrictedArea>
-    <RestrictedArea Type="Danger" Name="D621 TRENTHAM" AltitudeFloor="0" AltitudeCeiling="1500" DAIWEnabled="true" LinePattern="Dotted">
-      <Area>
--410836.500+1750244.790/
--410902.810+1750310.110/
--410950.560+1750224.460/
--410933.760+1750217.220/
--410919.440+1750220.270/
--410851.490+1750212.360/
--410847.790+1750210.020/
--410846.070+1750212.440/
--410847.240+1750220.020/
--410836.500+1750244.790</Area>
-      <Activations>
-        <Activation H24="true" Start="0000" End="0000" />
-      </Activations>
-    </RestrictedArea>
-    <RestrictedArea Type="Danger" Name="D626 BIG BUSH" AltitudeFloor="0" AltitudeCeiling="5500" DAIWEnabled="true" LinePattern="Dotted">
-      <Area>
--414020.200+1725234.300/
--414707.100+1725337.700/
--414625.900+1724636.300/
--414401.500+1724242.600/
--414106.400+1724603.300/
--414028.900+1724736.600/
--414020.200+1725234.300</Area>
-      <Activations>
-        <Activation H24="true" Start="0000" End="0000" />
-      </Activations>
-    </RestrictedArea>
-    <RestrictedArea Type="Danger" Name="D711 WAI-ITI CREEK" AltitudeFloor="0" AltitudeCeiling="3000" DAIWEnabled="true" LinePattern="Dotted">
-      <Area>
--422344.100+1714926.300/
--422620.200+1714732.800/
--422350.500+1714122.800/
--422117.100+1714319.800/
--422344.100+1714926.300</Area>
-      <Activations>
-        <Activation H24="true" Start="0000" End="0000" />
-      </Activations>
-    </RestrictedArea>
-    <RestrictedArea Type="Danger" Name="D721 PAPAROA FOREST" AltitudeFloor="0" AltitudeCeiling="3500" DAIWEnabled="true" LinePattern="Dotted">
-      <Area>
--421212.900+1713322.800/
--421318.000+1713316.700/
--421903.200+1713219.900/
--422045.600+1712606.700/
--421716.800+1712410.000/
--421423.700+1712618.200/
--421147.800+1712750.400/
--421212.900+1713322.800</Area>
-      <Activations>
-        <Activation H24="true" Start="0000" End="0000" />
-      </Activations>
-    </RestrictedArea>
-    <RestrictedArea Type="Danger" Name="D723 STOCKTON" AltitudeFloor="0" AltitudeCeiling="5000" DAIWEnabled="true" LinePattern="Dotted">
-      <Area>
--413741.880+1715507.320/
--413857.120+1715423.040/
--414135.160+1715515.240/
--414225.920+1715442.120/
--414314.520+1715332.280/
--414323.880+1715103.600/
--414237.440+1714959.160/
--414148.120+1714954.120/
--413830.840+1715053.880/
--413727.840+1715137.800/
--413630.240+1715237.200/
--413636.000+1715258.440/
--413722.080+1715332.280/
--413741.880+1715507.320</Area>
-      <Activations>
-        <Activation H24="true" Start="0000" End="0000" />
-      </Activations>
-    </RestrictedArea>
-    <RestrictedArea Type="Danger" Name="D820 MARUIA" AltitudeFloor="0" AltitudeCeiling="6500" DAIWEnabled="true" LinePattern="Dotted">
-      <Area>
--420856.900+1722003.500/
--421132.900+1722032.500/
--421441.900+1722005.500/
--421536.900+1721313.500/
--420759.900+1721417.500/
--420856.900+1722003.500</Area>
-      <Activations>
-        <Activation H24="true" Start="0000" End="0000" />
-      </Activations>
-    </RestrictedArea>
-    <RestrictedArea Type="Danger" Name="D822 RETREAT CREEK" AltitudeFloor="0" AltitudeCeiling="5000" DAIWEnabled="true" LinePattern="Dotted">
-      <Area>
--425628.700+1722403.800/
--425913.800+1722246.200/
--425918.000+1721635.200/
--425617.100+1721621.300/
--425628.700+1722403.800</Area>
-      <Activations>
-        <Activation H24="true" Start="0000" End="0000" />
-      </Activations>
-    </RestrictedArea>
-    <RestrictedArea Type="Danger" Name="D827 WEST MELTON" AltitudeFloor="0" AltitudeCeiling="1350" DAIWEnabled="true" LinePattern="Dotted">
-      <Area>
--432800.000+1722211.200/
--432922.800+1722154.400/
--432928.600+1722150.800/
--432923.400+1722116.600/
--432912.000+1722119.600/
--432906.600+1722100.400/
--432856.400+1722044.800/
--432800.600+1722035.800/
--432800.000+1722211.200</Area>
-      <Activations>
-        <Activation H24="true" Start="0000" End="0000" />
-      </Activations>
-    </RestrictedArea>
-    <RestrictedArea Type="Danger" Name="D921 MIDDLEMARCH" AltitudeFloor="0" AltitudeCeiling="8700" DAIWEnabled="true" LinePattern="Dotted">
-      <Area>
--453039.000+1695533.600/
--453159.300+1695620.300/
--453709.000+1695541.900/
--453818.500+1694814.600/
--453400.800+1694614.000/
--453145.400+1694916.100/
--453039.000+1695533.600</Area>
-      <Activations>
-        <Activation H24="true" Start="0000" End="0000" />
-      </Activations>
-    </RestrictedArea>
-    <RestrictedArea Type="Danger" Name="D925 WAITATI" AltitudeFloor="0" AltitudeCeiling="2000" DAIWEnabled="true" LinePattern="Dotted">
-      <Area>
--454546.200+1703230.300/
--454616.200+1703212.300/
--454559.200+1703106.300/
--454529.200+1703124.300/
--454546.200+1703230.300</Area>
-      <Activations>
-        <Activation H24="true" Start="0000" End="0000" />
-      </Activations>
-    </RestrictedArea>
-    <RestrictedArea Type="Danger" Name="D926 PUKAKI" AltitudeFloor="0" AltitudeCeiling="12500" DAIWEnabled="true" LinePattern="Dotted">
-      <Area>
--435413.500+1702242.500/
--435517.600+1701949.800/
--435653.300+1701507.900/
--435416.700+1701358.100/
--435253.300+1701955.900/
--435413.500+1702242.500</Area>
-      <Activations>
-        <Activation H24="true" Start="0000" End="0000" />
-      </Activations>
-    </RestrictedArea>
-    <RestrictedArea Type="Danger" Name="D927 BRAEMAR" AltitudeFloor="0" AltitudeCeiling="0" DAIWEnabled="true" LinePattern="Dotted">
-      <Area>
--435517.600+1701949.800/
--435831.800+1702015.300/
--435824.000+1701758.500/
--435858.600+1701603.800/
--435653.300+1701507.900/
--435517.600+1701949.800</Area>
-      <Activations />
-    </RestrictedArea>
-    <RestrictedArea Type="Danger" Name="D928 TEKAPO" AltitudeFloor="0" AltitudeCeiling="0" DAIWEnabled="true" LinePattern="Dotted">
-      <Area>
--435504.000+1702603.000/
--435656.500+1702625.700/
--435807.700+1702427.500/
--435751.900+1702252.500/
--435831.800+1702015.300/
--435517.600+1701949.800/
--435413.500+1702242.500/
--435450.900+1702338.500/
--435504.000+1702603.000</Area>
-      <Activations />
-    </RestrictedArea>
     <RestrictedArea Type="Restricted" Name="M102 BAY OF ISLANDS" AltitudeFloor="0" AltitudeCeiling="0" DAIWEnabled="true" LinePattern="Solid">
       <Area>
 -343000.000+1745000.000/
@@ -921,6 +613,314 @@
       <Activations>
         <Activation H24="true" Start="0000" End="0000" />
       </Activations>
+    </RestrictedArea>
+    <RestrictedArea Type="Danger" Name="D121 ONETAUNGA BAY" AltitudeFloor="0" AltitudeCeiling="1500" DAIWEnabled="true" LinePattern="Dotted">
+      <Area>
+-364905.800+1744150.000/
+-364906.046+1744153.514/
+-364906.777+1744156.921/
+-364907.970+1744200.118/
+-364909.590+1744203.008/
+-364911.587+1744205.502/
+-364913.900+1744207.526/
+-364916.459+1744209.017/
+-364919.186+1744209.930/
+-364922.000+1744210.238/
+-364924.813+1744209.930/
+-364927.540+1744209.017/
+-364930.100+1744207.527/
+-364932.413+1744205.503/
+-364934.410+1744203.009/
+-364936.029+1744200.119/
+-364937.223+1744156.922/
+-364937.954+1744153.514/
+-364938.200+1744150.000/
+-364937.954+1744146.486/
+-364937.223+1744143.078/
+-364936.029+1744139.881/
+-364934.410+1744136.991/
+-364932.413+1744134.497/
+-364930.100+1744132.473/
+-364927.540+1744130.983/
+-364924.813+1744130.070/
+-364922.000+1744129.762/
+-364919.186+1744130.070/
+-364916.459+1744130.983/
+-364913.900+1744132.474/
+-364911.587+1744134.498/
+-364909.590+1744136.992/
+-364907.970+1744139.882/
+-364906.777+1744143.079/
+-364906.046+1744146.486/
+-364905.800+1744150.000</Area>
+      <Activations>
+        <Activation H24="true" Start="0000" End="0000" />
+      </Activations>
+    </RestrictedArea>
+    <RestrictedArea Type="Danger" Name="D125 TIRITIRI MATANGI" AltitudeFloor="0" AltitudeCeiling="0" DAIWEnabled="true" LinePattern="Dotted">
+      <Area>
+-363131.800+1745456.900/
+-363530.000+1745456.900/
+-363530.000+1745240.400/
+-363636.300+1745240.400/
+-363617.500+1745020.000/
+-363542.000+1744900.000/
+-363131.800+1744900.000/
+-363131.800+1745456.900</Area>
+      <Activations />
+    </RestrictedArea>
+    <RestrictedArea Type="Danger" Name="D130 WHANGAPARAOA HEAD" AltitudeFloor="0" AltitudeCeiling="1200" DAIWEnabled="true" LinePattern="Dotted">
+      <Area>
+-363350.200+1745240.400/
+-363636.300+1745240.400/
+-363617.500+1745020.000/
+-363542.000+1744900.000/
+-363350.200+1744900.000/
+-363350.200+1745240.400</Area>
+      <Activations>
+        <Activation H24="true" Start="0000" End="0000" />
+      </Activations>
+    </RestrictedArea>
+    <RestrictedArea Type="Danger" Name="D235 DRURY AERODROME" AltitudeFloor="0" AltitudeCeiling="2500" DAIWEnabled="true" LinePattern="Dotted">
+      <Area>
+-370447.200+1745831.800/
+-370448.111+1745844.860/
+-370450.818+1745857.523/
+-370455.237+1745909.405/
+-370501.235+1745920.145/
+-370508.629+1745929.417/
+-370517.195+1745936.938/
+-370526.673+1745942.482/
+-370536.775+1745945.878/
+-370547.193+1745947.024/
+-370557.612+1745945.884/
+-370607.715+1745942.492/
+-370617.195+1745936.953/
+-370625.763+1745929.433/
+-370633.160+1745920.161/
+-370639.160+1745909.419/
+-370643.581+1745857.533/
+-370646.288+1745844.865/
+-370647.200+1745831.800/
+-370646.288+1745818.735/
+-370643.581+1745806.067/
+-370639.160+1745754.181/
+-370633.160+1745743.439/
+-370625.763+1745734.167/
+-370617.195+1745726.647/
+-370607.715+1745721.108/
+-370557.612+1745717.716/
+-370547.193+1745716.576/
+-370536.775+1745717.722/
+-370526.673+1745721.118/
+-370517.195+1745726.662/
+-370508.629+1745734.183/
+-370501.235+1745743.455/
+-370455.237+1745754.195/
+-370450.818+1745806.077/
+-370448.111+1745818.740/
+-370447.200+1745831.800</Area>
+      <Activations>
+        <Activation H24="true" Start="0000" End="0000" />
+      </Activations>
+    </RestrictedArea>
+    <RestrictedArea Type="Danger" Name="D323 TARERE FOREST" AltitudeFloor="0" AltitudeCeiling="2600" DAIWEnabled="true" LinePattern="Dotted">
+      <Area>
+-393243.700+1743406.600/
+-393703.700+1743132.600/
+-393541.700+1742634.600/
+-393458.700+1742659.600/
+-393157.700+1742808.600/
+-393144.700+1743003.600/
+-393243.700+1743406.600</Area>
+      <Activations>
+        <Activation H24="true" Start="0000" End="0000" />
+      </Activations>
+    </RestrictedArea>
+    <RestrictedArea Type="Danger" Name="D522 MANGAHAO" AltitudeFloor="0" AltitudeCeiling="2500" DAIWEnabled="true" LinePattern="Dotted">
+      <Area>
+-402644.700+1754848.800/
+-402928.000+1754552.000/
+-402910.200+1754341.700/
+-402800.300+1754059.200/
+-402640.800+1754130.500/
+-402610.100+1754221.100/
+-402544.400+1754717.600/
+-402644.700+1754848.800</Area>
+      <Activations>
+        <Activation H24="true" Start="0000" End="0000" />
+      </Activations>
+    </RestrictedArea>
+    <RestrictedArea Type="Danger" Name="D621 TRENTHAM" AltitudeFloor="0" AltitudeCeiling="1500" DAIWEnabled="true" LinePattern="Dotted">
+      <Area>
+-410836.500+1750244.790/
+-410902.810+1750310.110/
+-410950.560+1750224.460/
+-410933.760+1750217.220/
+-410919.440+1750220.270/
+-410851.490+1750212.360/
+-410847.790+1750210.020/
+-410846.070+1750212.440/
+-410847.240+1750220.020/
+-410836.500+1750244.790</Area>
+      <Activations>
+        <Activation H24="true" Start="0000" End="0000" />
+      </Activations>
+    </RestrictedArea>
+    <RestrictedArea Type="Danger" Name="D626 BIG BUSH" AltitudeFloor="0" AltitudeCeiling="5500" DAIWEnabled="true" LinePattern="Dotted">
+      <Area>
+-414020.200+1725234.300/
+-414707.100+1725337.700/
+-414625.900+1724636.300/
+-414401.500+1724242.600/
+-414106.400+1724603.300/
+-414028.900+1724736.600/
+-414020.200+1725234.300</Area>
+      <Activations>
+        <Activation H24="true" Start="0000" End="0000" />
+      </Activations>
+    </RestrictedArea>
+    <RestrictedArea Type="Danger" Name="D711 WAI-ITI CREEK" AltitudeFloor="0" AltitudeCeiling="3000" DAIWEnabled="true" LinePattern="Dotted">
+      <Area>
+-422344.100+1714926.300/
+-422620.200+1714732.800/
+-422350.500+1714122.800/
+-422117.100+1714319.800/
+-422344.100+1714926.300</Area>
+      <Activations>
+        <Activation H24="true" Start="0000" End="0000" />
+      </Activations>
+    </RestrictedArea>
+    <RestrictedArea Type="Danger" Name="D721 PAPAROA FOREST" AltitudeFloor="0" AltitudeCeiling="3500" DAIWEnabled="true" LinePattern="Dotted">
+      <Area>
+-421212.900+1713322.800/
+-421318.000+1713316.700/
+-421903.200+1713219.900/
+-422045.600+1712606.700/
+-421716.800+1712410.000/
+-421423.700+1712618.200/
+-421147.800+1712750.400/
+-421212.900+1713322.800</Area>
+      <Activations>
+        <Activation H24="true" Start="0000" End="0000" />
+      </Activations>
+    </RestrictedArea>
+    <RestrictedArea Type="Danger" Name="D723 STOCKTON" AltitudeFloor="0" AltitudeCeiling="5000" DAIWEnabled="true" LinePattern="Dotted">
+      <Area>
+-413741.880+1715507.320/
+-413857.120+1715423.040/
+-414135.160+1715515.240/
+-414225.920+1715442.120/
+-414314.520+1715332.280/
+-414323.880+1715103.600/
+-414237.440+1714959.160/
+-414148.120+1714954.120/
+-413830.840+1715053.880/
+-413727.840+1715137.800/
+-413630.240+1715237.200/
+-413636.000+1715258.440/
+-413722.080+1715332.280/
+-413741.880+1715507.320</Area>
+      <Activations>
+        <Activation H24="true" Start="0000" End="0000" />
+      </Activations>
+    </RestrictedArea>
+    <RestrictedArea Type="Danger" Name="D820 MARUIA" AltitudeFloor="0" AltitudeCeiling="6500" DAIWEnabled="true" LinePattern="Dotted">
+      <Area>
+-420856.900+1722003.500/
+-421132.900+1722032.500/
+-421441.900+1722005.500/
+-421536.900+1721313.500/
+-420759.900+1721417.500/
+-420856.900+1722003.500</Area>
+      <Activations>
+        <Activation H24="true" Start="0000" End="0000" />
+      </Activations>
+    </RestrictedArea>
+    <RestrictedArea Type="Danger" Name="D822 RETREAT CREEK" AltitudeFloor="0" AltitudeCeiling="5000" DAIWEnabled="true" LinePattern="Dotted">
+      <Area>
+-425628.700+1722403.800/
+-425913.800+1722246.200/
+-425918.000+1721635.200/
+-425617.100+1721621.300/
+-425628.700+1722403.800</Area>
+      <Activations>
+        <Activation H24="true" Start="0000" End="0000" />
+      </Activations>
+    </RestrictedArea>
+    <RestrictedArea Type="Danger" Name="D827 WEST MELTON" AltitudeFloor="0" AltitudeCeiling="1350" DAIWEnabled="true" LinePattern="Dotted">
+      <Area>
+-432800.000+1722211.200/
+-432922.800+1722154.400/
+-432928.600+1722150.800/
+-432923.400+1722116.600/
+-432912.000+1722119.600/
+-432906.600+1722100.400/
+-432856.400+1722044.800/
+-432800.600+1722035.800/
+-432800.000+1722211.200</Area>
+      <Activations>
+        <Activation H24="true" Start="0000" End="0000" />
+      </Activations>
+    </RestrictedArea>
+    <RestrictedArea Type="Danger" Name="D921 MIDDLEMARCH" AltitudeFloor="0" AltitudeCeiling="8700" DAIWEnabled="true" LinePattern="Dotted">
+      <Area>
+-453039.000+1695533.600/
+-453159.300+1695620.300/
+-453709.000+1695541.900/
+-453818.500+1694814.600/
+-453400.800+1694614.000/
+-453145.400+1694916.100/
+-453039.000+1695533.600</Area>
+      <Activations>
+        <Activation H24="true" Start="0000" End="0000" />
+      </Activations>
+    </RestrictedArea>
+    <RestrictedArea Type="Danger" Name="D925 WAITATI" AltitudeFloor="0" AltitudeCeiling="2000" DAIWEnabled="true" LinePattern="Dotted">
+      <Area>
+-454546.200+1703230.300/
+-454616.200+1703212.300/
+-454559.200+1703106.300/
+-454529.200+1703124.300/
+-454546.200+1703230.300</Area>
+      <Activations>
+        <Activation H24="true" Start="0000" End="0000" />
+      </Activations>
+    </RestrictedArea>
+    <RestrictedArea Type="Danger" Name="D926 PUKAKI" AltitudeFloor="0" AltitudeCeiling="12500" DAIWEnabled="true" LinePattern="Dotted">
+      <Area>
+-435413.500+1702242.500/
+-435517.600+1701949.800/
+-435653.300+1701507.900/
+-435416.700+1701358.100/
+-435253.300+1701955.900/
+-435413.500+1702242.500</Area>
+      <Activations>
+        <Activation H24="true" Start="0000" End="0000" />
+      </Activations>
+    </RestrictedArea>
+    <RestrictedArea Type="Danger" Name="D927 BRAEMAR" AltitudeFloor="0" AltitudeCeiling="0" DAIWEnabled="true" LinePattern="Dotted">
+      <Area>
+-435517.600+1701949.800/
+-435831.800+1702015.300/
+-435824.000+1701758.500/
+-435858.600+1701603.800/
+-435653.300+1701507.900/
+-435517.600+1701949.800</Area>
+      <Activations />
+    </RestrictedArea>
+    <RestrictedArea Type="Danger" Name="D928 TEKAPO" AltitudeFloor="0" AltitudeCeiling="0" DAIWEnabled="true" LinePattern="Dotted">
+      <Area>
+-435504.000+1702603.000/
+-435656.500+1702625.700/
+-435807.700+1702427.500/
+-435751.900+1702252.500/
+-435831.800+1702015.300/
+-435517.600+1701949.800/
+-435413.500+1702242.500/
+-435450.900+1702338.500/
+-435504.000+1702603.000</Area>
+      <Activations />
     </RestrictedArea>
     <RestrictedArea Type="Restricted" Name="R100 MARSDEN POINT" AltitudeFloor="0" AltitudeCeiling="3500" DAIWEnabled="true" LinePattern="Dotted">
       <Area>


### PR DESCRIPTION
Includes changes from:

- f97bb27, ec50091, e341b83, 65bb568, 299cb61, 3e658ee, 7d856d3

Additional changes:

- Fix long map line errors in TU_ACU
- Fix Q472 drawing incorrectly
- Update some old STAR names that were missed in 7d856d3