### PR TITLE
fix: LML errors in cycle 2502

### DIFF
--- a/Maps/Airspace/ALL_RNAV.xml
+++ b/Maps/Airspace/ALL_RNAV.xml
@@ -1045,8 +1045,8 @@
     <Line Pattern="Solid">SUNPA/EMTEP/-441740.679+1711352.540</Line>
     <Line Pattern="Solid">BIDNI/SUNPA</Line>
     <Line Pattern="Solid">LUVAB/SUNPA</Line>
-    <Line Pattern="Solid">LUTKA/ELKUB/ENPIP/WB401/-413102.701+1735240.462</Line>
-    <Line Pattern="Solid">JAMIE/LUTKA</Line>
+    <Line Pattern="Solid">LUTKA/REKID/ENPIP/WB401/-413102.701+1735240.462</Line>
+    <Line Pattern="Solid">EXOTA/LUTKA</Line>
     <Line Pattern="Solid">KAKVA/PILAD/SAGEM/-444334.000+1691505.000</Line>
     <Line Pattern="Solid">ARIGU/KAKVA</Line>
     <Line Pattern="Solid">PASMU/KAKVA</Line>

--- a/Maps/NZWB/WB_ACU.xml
+++ b/Maps/NZWB/WB_ACU.xml
@@ -286,7 +286,7 @@
   <Map Type="System2" Name="24 RNP" Priority="1" Center="-41.517417+173.877906" CustomColourName="ProcArr">
     <!--Fix Symbols-->
     <Symbol Type="HollowTriangle">
-      <Point>ELKUB</Point>
+      <Point>REKID</Point>
       <Point>WB401</Point>
     </Symbol>
     <!--IAF Symbols-->
@@ -300,8 +300,8 @@
     </Symbol>
     <!--IF Symbols-->
     <Symbol Type="SolidTriangle" />
-    <Line Pattern="Solid">LUTKA/ELKUB/ENPIP/WB401/-413102.701+1735240.462</Line>
-    <Line Pattern="Solid">JAMIE/LUTKA</Line>
+    <Line Pattern="Solid">LUTKA/REKID/ENPIP/WB401/-413102.701+1735240.462</Line>
+    <Line Pattern="Solid">EXOTA/LUTKA</Line>
   </Map>
   <Map Type="System2" Name="24 RNP Labels" Priority="1" Center="-41.517417+173.877906" CustomColourName="ProcArr">
     <Label HasLeader="true">


### PR DESCRIPTION
- fixes long map line error for `ELKUB` `ENPIP` and `LUTKA`
- `JAMIE` replaced by`EXOTA` Cycle 2502
- `ELKUB` replaced by `REKID` unknown Cycle